### PR TITLE
Try to support AEAddition NBT

### DIFF
--- a/src/main/java/com/mekeng/github/common/me/data/impl/AEGasStack.java
+++ b/src/main/java/com/mekeng/github/common/me/data/impl/AEGasStack.java
@@ -46,7 +46,23 @@ public final class AEGasStack extends AEStack<IAEGasStack> implements IAEGasStac
     }
 
     @Nullable
+    public static AEGasStack of(Gas input) {
+        return input == null ? null : new AEGasStack(input, 0);
+    }
+
+    @Nullable
     public static IAEGasStack of(NBTTagCompound data) {
+        long amount = data.getLong("amount");
+        if (amount > Integer.MAX_VALUE) {
+            Gas gas = Gas.readFromNBT(data);
+            if (gas == null) {
+                return null;
+            }
+            return of(gas)
+                    .setStackSize(amount)
+                    .setCountRequestable(data.getLong("countRequestable"))
+                    .setCraftable(data.getBoolean("isCraftable"));
+        }
         GasStack gasStack = GasStack.readFromNBT(data);
         if (gasStack == null) {
             return null;


### PR DESCRIPTION
resolve #3 

尝试支持AEAddition 的NBT键，比较粗糙。需要AEA侧更换存储频道。个人认为不太合适作为公共补丁。

该PR的目的是为了方便将AEA的磁盘数据转移至MekE的磁盘中。补丁没有充分考虑以下两个Key 的值

`
this.isCraftable = nbt.getBoolean("isCraftable")
this.countRequestable = nbt.getLong("countRequestable")`

@GlodBlock 作者你怎么看？